### PR TITLE
autounattend: Add support Windows Evaluation ISO

### DIFF
--- a/answer-files/autounattend.xml.in
+++ b/answer-files/autounattend.xml.in
@@ -50,7 +50,7 @@
             <UserData>
                 <AcceptEula>true</AcceptEula>
                 <ProductKey>
-                    <Key>@PRODUCT_KEY@</Key>
+                    @PRODUCT_KEY_XML@
                 </ProductKey>
             </UserData>
             <ImageInstall>


### PR DESCRIPTION
For unattended installation of the evaluation version of Windows
product key should be not specified.

Add a new replacement word for this scenario.

Signed-off-by: Kostiantyn Kostiuk <konstantin@daynix.com>