### PR TITLE
Add the ability to install drivers during the installation

### DIFF
--- a/answer-files/autounattend.xml.bios.in
+++ b/answer-files/autounattend.xml.bios.in
@@ -12,6 +12,13 @@
             <UserLocale>en-US</UserLocale>
             <InputLocale>0409:00000409</InputLocale>
         </component>
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DriverPaths>
+                <PathAndCredentials wcm:keyValue="1" wcm:action="add">
+                    <Path>d:\drivers\</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
         <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DiskConfiguration>
                 <Disk wcm:action="add">
@@ -70,4 +77,3 @@
         </component>
     </settings>
 </unattend>
-

--- a/answer-files/autounattend.xml.uefi.in
+++ b/answer-files/autounattend.xml.uefi.in
@@ -12,6 +12,13 @@
             <UserLocale>en-US</UserLocale>
             <InputLocale>0409:00000409</InputLocale>
         </component>
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DriverPaths>
+                <PathAndCredentials wcm:keyValue="1" wcm:action="add">
+                    <Path>d:\drivers\</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
         <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DiskConfiguration>
                 <Disk wcm:action="add">

--- a/answer-files/unattend.xml.in
+++ b/answer-files/unattend.xml.in
@@ -27,7 +27,7 @@
             </UserAccounts>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>reg add "HKLM\Software\Microsoft\Windows\CurrentVersion\Run" /v "install" /d "powershell.exe -ExecutionPolicy ByPass -File D:\@HOST_TYPE@.ps1" /f</CommandLine>
+                    <CommandLine>cmd /c for %i in (a b c d e f g h i j k l m n o p q r s t u v w x y z) do if exist %i:\@HOST_TYPE@.ps1 reg add "HKLM\Software\Microsoft\Windows\CurrentVersion\Run" /v "install" /d "powershell.exe -ExecutionPolicy ByPass -File %i:\@HOST_TYPE@.ps1" /f</CommandLine>
                     <Description>Install all deps</Description>
                     <Order>1</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/drivers/.gitignore
+++ b/drivers/.gitignore
@@ -1,0 +1,3 @@
+*
+!README.md
+!.gitignore

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -1,0 +1,3 @@
+# Drivers directory
+
+This directory is used for storing drivers for installation


### PR DESCRIPTION
When the storage driver is installed, Windows re-enumerates the drive's letter. So, the installer ISO can be moved. Let's enumerate all drives in unattend.xml and find where the installer is located.