### PR TITLE
Wrap SB check into try/catch

### DIFF
--- a/client.ps1
+++ b/client.ps1
@@ -41,9 +41,15 @@ function Stage-One {
     "$STUDIOIP $STUDIOCOMPUTERNAME #STUDIO VM IP" |  Out-File -encoding ASCII -append 'C:\Windows\System32\drivers\etc\hosts'
 
     if ($env:FIRMWARE_TYPE -eq 'UEFI') {
-        if (Confirm-SecureBootUEFI) {
-            Write-Output "Secure boot enabled, skipping TestSigning on..."
-        } else {
+        try {
+            if (Confirm-SecureBootUEFI) {
+                Write-Output "Secure boot enabled, skipping TestSigning on..."
+            } else {
+                Write-Output "Setting TestSigning on..."
+                Execute-Command -Path "bcdedit.exe" -Arguments "/set testsigning on"
+            }
+        } catch {
+            Write-Output "Confirm-SecureBootUEFI crashed, secure boot is not enabled"
             Write-Output "Setting TestSigning on..."
             Execute-Command -Path "bcdedit.exe" -Arguments "/set testsigning on"
         }


### PR DESCRIPTION
In Windows Server vNext Confirm-SecureBootUEFI crashes when booting in UEFI mode with disabled Secure boot instead of returning $False.

According to MSDN, this behavior is possible if the computer does not support Secure Boot or is a
BIOS (non-UEFI) computer.