### PR TITLE
VIRTWINKVM-1841: Add system configuration functions for UAC, crash control

### DIFF
--- a/client.ps1
+++ b/client.ps1
@@ -22,6 +22,8 @@ function Stage-One {
     Disable-WindowsUpdate
     Disable-Screensaver
     Disable-PowerSavingOptions
+    Disable-UserAccountControl
+    Configure-CrashControl
 
     Get-NetAdapter | ForEach-Object {
         $adapterName = $_.Name

--- a/common.ps1
+++ b/common.ps1
@@ -75,6 +75,45 @@ function Enable-RemoteDesktop {
     Write-Output "Remote Desktop has been enabled"
 }
 
+function Disable-UserAccountControl {
+    Write-Output "Disabling User Account Control (UAC)..."
+
+    # Disable UAC by setting EnableLUA to 0
+    Set-Registry -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" `
+        -Name "EnableLUA" -Type DWord -Value 0
+
+    # Set FilterAdministratorToken to 0 to disable UAC for built-in administrator
+    Set-Registry -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" `
+        -Name "FilterAdministratorToken" -Type DWord -Value 0
+
+    Write-Output "UAC has been disabled. A restart is required for changes to take effect."
+}
+
+function Configure-CrashControl {
+    Write-Output "Configuring crash control settings..."
+
+    # Enable NMI crash dump (allows triggering crash dumps via NMI)
+    Set-Registry -Path "HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl" `
+        -Name "NMICrashDump" -Type DWord -Value 1
+
+    # Set crash dump to kernel memory dump (value 2)
+    Set-Registry -Path "HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl" `
+        -Name "CrashDumpEnabled" -Type DWord -Value 2
+
+    # Configure AutoReboot setting based on no_reboot_after_bugcheck parameter
+    if ($NOREBOOTAFTERBUGCHECK -eq $TRUE) {
+        Write-Output "Disabling automatic reboot after crash (keeps the system in crashed state for debugging)"
+        Set-Registry -Path "HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl" `
+            -Name "AutoReboot" -Type DWord -Value 0
+    } else {
+        Write-Output "Enabling automatic reboot after crash (default behavior)"
+        Set-Registry -Path "HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl" `
+            -Name "AutoReboot" -Type DWord -Value 1
+    }
+
+    Write-Output "Crash control settings have been configured."
+}
+
 function Remove-WindowsGUI {
     Write-Output "Removing windows GUI..."
     Remove-WindowsFeature Server-Gui-Shell, Server-Gui-Mgmt-Infra


### PR DESCRIPTION
1. Add Disable-UserAccountControl function to disable UAC settings
2. Add Configure-CrashControl function for NMI crash dumps and kernel memory dumps

depend on: https://github.com/HCK-CI/AutoHCK/pull/813